### PR TITLE
Fix/build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ As a contributor, you are expected to fork this repository, work on your own for
 cd beefy-moobird
 git remote add upstream https://github.com/beefyfinance/beefy-moobird.git
 git fetch upstream
-git pull --rebase upstream master
+git pull --rebase upstream main
 ```
 NOTE: The directory `beefy-moobird` represents your fork's local copy.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord==1.0.1
 discord.py==1.7.1
 PyYAML==5.4.1
-git+https://github.com/tweepy/tweepy.git
+tweepy@git+https://github.com/tweepy/tweepy.git
 emoji~=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord==1.0.1
 discord.py==1.7.1
 PyYAML==5.4.1
-tweepy==3.10.0
+git+https://github.com/tweepy/tweepy.git
 emoji~=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord==1.0.1
 discord.py==1.7.1
 PyYAML==5.4.1
-tweepy@git+https://github.com/tweepy/tweepy.git@async-streaming
+tweepy==3.10.0
 emoji~=1.2.0


### PR DESCRIPTION
Changes contributing file command to point to main rather than master

Moves tweepy build from an old @async-streaming branch that has been removed: https://github.com/tweepy/tweepy/issues/1625 onto tweepy==3.10.0.

